### PR TITLE
Veeam Deployments using Chef-Solo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This Repository contains example Terraform templaes for use with the Veeam Chef 
 | --- | --- | --- | --- |
 | [veeam_standalone_full](vmware/chef_server/veeam_standalone_full) | VMware | X | This set of templates will deploy Veeam Backup and Replication server in a complete deployment along with an optional number of Veeam VMware Proxies on VMware using Chef Server. |
 | [veeam_proxy](vmware/chef_server/veeam_proxy) | VMware | X | This set of templates will deploy one or more Veeam VMware Proxy Servers on VMware using Chef Server. |
+| [no_chef_server:veeam_standalone_full](vmware/no_chef_server/veeam_standalone_full) | VMware |  | This set of templates will deploy Veeam Backup and Replication server in a complete deployment along with an optional number of Veeam VMware Proxies on VMware using Chef-Solo mode with the Chef Client. |
+| [no_chef_server:veeam_proxy](vmware/no_chef_server/veeam_proxy) | VMware |  | This set of templates will deploy one or more Veeam VMware Proxy Servers on VMware using Chef-Solo mode with the Chef Client. |
 
 ## Contribute
  - Fork it

--- a/vmware/no_chef_server/veeam_proxy/README.md
+++ b/vmware/no_chef_server/veeam_proxy/README.md
@@ -1,0 +1,129 @@
+# Basic Deployment of Veeam Proxy Servers on VMware
+This set of templates will deploy one or more Veeam VMware Proxy Servers on VMware using Chef Server.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Requirements](#requirements)
+- [Getting Started](#getting-started)
+- [Terraform Variable Declarations](#terraform-variable-declarations)
+  - [VMware Variables](#vmware-variables)
+  - [Veeam Server Variables](#veeam-server-variables)
+  - [Chef Server Variables](#chef-server-variables)
+- [Veeam Backup and Replication ISO](#veeam-backup-and-replication-iso)
+- [Terraform Execution Commands](#terraform-execution-commands)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Requirements
+
+- [Terraform 0.11.8+](https://www.terraform.io/downloads.html)
+- Chef Server 12+
+- Windows 2012R2 or Windows 2016 VMware Template
+- vSphere Credentials
+
+## Getting Started
+The Terraform templates included in this repository requires Terraform to be available locally on the machine running the templates.  Before you begin, please verify that you have the following information:
+
+1. Download [Terraform](https://www.terraform.io/downloads.html) (minimum tested version 0.11.8) binary to your workstation.
+2. Gather the VMware credentials required to communicate to vCenter
+3. Find the VMware template name to use and the VMware folder to which the machines would be deployed.
+4. Register for a [Hosted Chef](https://manage.chef.io/signup) account or if using Chef on-premises, then get a username and private key file.
+5. Get the Chef Organization URL to use.
+6. Save a copy of the file `terraform.tfvars.example` as `terraform.tfvars`
+7. Update the variable values in the newly created `terraform.tfvars` file.
+8. Run `terraform init` to install the required plugins and modules
+9. Test the variables and templates by running `terraform plan`
+10. If everything looks good, then create the environment by running `terraform apply`
+
+[More information on optional Terraform Configurations](#terraform-execution-commands)
+
+## Terraform Variable Declarations
+
+### VMware Variables
+
+| Name | Type | Description | Default Value | Mandatory |
+| --- | --- | --- | --- | --- |
+| `vsphere_server` | String | vCenter FQDN or IP to which the systems will be deployed. | | X |
+| `vsphere_user` | String | vCenter Username with privileges to deploy machines | | X |
+| `vsphere_password` | String | vCenter Password of User selected | | X |
+| `datacenter` | String | vSphere Datacenter Name to which the systems will be deployed. | | X |
+| `vsphere_resource_pool` | String | vSphere Cluster or Resource Pool to which the systems will be deployed. | | X |
+| `vsphere_network_name` | String | vSphere Virtual Machine Network to which the systems will be attached. | | X |
+
+### Veeam Server Variables
+
+| Name | Type | Description | Default Value | Mandatory |
+| --- | --- | --- | --- | --- |
+| `proxy_template_path` | String | Optional] vSphere Full Template Path from which the Proxy systems will be deployed.  If empty or 'same' then the variable veeam_template_path will be used. | "same" | X |
+| `proxy_cpu_count` | String | Total number of vCPUs to assign to Veeam Proxy Server | 2 | X |
+| `proxy_memory_size_mb` | String | Total amount of memory (MB) to assign to Veeam Proxy Server. | 2048 | X |
+| `should_register_proxy` | String | Should the Veeam Proxy Server be registered to the Veeam VBR Server. | "true" | X |
+| `veeam_deployment_folder` | String | vSphere Folder to which the systems will be deployed.  Must exist prior to execution. | | X |
+| `vbr_server_address` | String | Veeam VBR Server Address.  Must exist prior to execution. | | X |
+| `admin_user` | String | Username for Remote Windows Management Connections.  Must be in Domain\\username or .\\username format. | | X |
+| `admin_password` | String | Password for Remote Windows Management Connections | | X |
+| `proxy_admin_user` | String | Username for Remote Windows Management Connections.  Must be in Domain\\username or .\\username format. | | X |
+| `proxy_admin_password` | String | Password for Remote Windows Management Connections | | X |
+| `domain_name` | String | FQDN domain name | | X |
+| `veeam_proxy_name` | String | Enter the hostname prefix to give to the Veeam Proxy Server.  Must be less than 12 characters as proxies will receive a 3 digit identifier at the end of their name. | "proxy" | X |
+| `proxy_count` | String | Number of Proxy Servers to create.  Zero will remove all proxies created by this Terraform State | 0 | X |
+
+### Chef Server Variables
+
+| Name | Type | Description | Default Value | Mandatory |
+| --- | --- | --- | --- | --- |
+| `chef_server_url` | String | Full Chef Organization URL to which these hosts will be configured. | | X |
+| `chef_username` | String | Chef Username with access to the assigned Chef Organization URL. | | X |
+| `chef_user_key` | String | Full File location on disk to the private key for the assigned Chef Username. | | X |
+| `chef_environment` | String | Chef Environment to which the servers will be configured. | "_default" | X |
+| `veeam_installation_url` | String | Full URL from which the Veeam software will be downloaded. | [VeeamBackup&Replication_9.5.0.1922.Update3a.iso](https://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.iso) | X |
+| `veeam_installation_checksum` | String | SHA256 Checksum for the ISO Url selected. | 9a6fa7d857396c058b2e65f20968de56f96bc293e0e8fd9f1a848c7d71534134 | X |
+
+
+## Veeam Backup and Replication ISO
+The attribute `node['veeam']['version']` is used to evaluate the ISO download path and checksum for the installation media.  When provided, the version selected will be downloaded based on the value found in `libraries/helper.rb`.  This media path can be overridden by providing the appropriate installation media attributes - `node['veeam']['installer']['package_url']` and `node['veeam']['installer']['package_checksum']`.  By default, these attributes are `nil` and the system will download the ISO every time.
+
+| Version | ISO URL | SHA256 |
+| ------------- |-------------|-------------|
+| **9.0** | [VeeamBackup&Replication_9.0.0.902.iso](http://download.veeam.com/VeeamBackup&Replication_9.0.0.902.iso) | 21f9d2c318911e668511990b8bbd2800141a7764cc97a8b78d4c2200c1225c88 |
+| **9.5** | [VeeamBackup&Replication_9.5.0.711.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.711.iso) | af3e3f6db9cb4a711256443894e6fb56da35d48c0b2c32d051960c52c5bc2f00 |
+| **9.5.0.711** | [VeeamBackup&Replication_9.5.0.711.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.711.iso) | af3e3f6db9cb4a711256443894e6fb56da35d48c0b2c32d051960c52c5bc2f00 |
+| **9.5.0.1038** | [VeeamBackup&Replication_9.5.0.1038.Update2.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1038.Update2.iso) | 180b142c1092c89001ba840fc97158cc9d3a37d6c7b25c93a311115b33454977 |
+| **9.5.0.1536** | [VeeamBackup&Replication_9.5.0.1536.Update3.iso](http://download.veeam.com/VeeamBackup&Replication_9.5.0.1536.Update3.iso) | 5020ef015e4d9ff7070d43cf477511a2b562d8044975552fd08f82bdcf556a43 |
+| **9.5.0.1922** | [VeeamBackup&Replication_9.5.0.1922.Update3a.iso](https://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.iso) | 9a6fa7d857396c058b2e65f20968de56f96bc293e0e8fd9f1a848c7d71534134 |
+
+## Terraform Execution Commands
+Below is a list of different command options when executing Terraform.
+
+| Command | Description | Result |
+| --- | --- | --- |
+| `terraform init` | Downloads all of the required plugins for Terraform to execute these templates. | Creates a .terraform directory in the location of the templates and pulls the current plugin versions. |
+| `terraform plan` | Runs validation checks against the Terraform templates and variables. | When run, it will display a list of changed items and what will be created or updated. |
+| `terraform apply` | Applies the Terraform templates to create the infrastructure needed to satisfy the configuration. If the `-auto-approve` switch is added, then it will bypass the *Should proceed?* question. | By default, will create only a new Veeam Backup and Replication server unless the `terraform.tfvars` file has the variable `proxy_count` set to a value greater than 0. |
+| `terraform apply -var proxy_count=2` | Applies the Terraform templates to create the infrastructure needed to satisfy the configuration and overrides the value for the variable `proxy_count`. | Variable values are selected by first the default value in `variables.tf`, second the value in the `terraform.tfvars` file, and third the command line value provided. In this case, we are overriding the number of proxy servers to create.  If previous executions set the value of `proxy_count` to 3, then this command would remove the last proxy server and leave only two proxy hosts. |
+| `terraform destroy` | Reverses the entire configuration and destroys the infrastructure. If the `-force` switch is added, then it will bypass the *Should proceed?* question. | **WARNING**: This will delete everything in your environment based on the templates.  If you only want to remove the proxies, then you can simply set the `proxy_count` variable as mentioned previously. |
+| `terraform apply -var proxy_count=1 -var should_register_proxy=false` | This command will build the Veeam VBR server and deploy one Proxy Server but not register the proxy to VBR. | This command is handy for staging a new Proxy Server template.  By deploying in this manner:<ol><li>you can prestage the installation of the Veeam components</li><li>shutdown the machine</li><li>clone to a new template</li><li>then power on the proxy server</li><li>finally, run the process again using `terraform apply -var proxy_count=0` to delete the proxy cleanly</li></ol>|
+
+
+## License and Author
+
+_Note: This repository is not officially supported by or released by Veeam Software, Inc._
+
+- Author:: Exosphere Data, LLC ([chef@exospheredata.com](mailto:chef@exospheredata.com))
+
+```text
+Copyright 2018 Exosphere Data, LLC
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+```
+
+

--- a/vmware/no_chef_server/veeam_proxy/files/Berksfile
+++ b/vmware/no_chef_server/veeam_proxy/files/Berksfile
@@ -1,0 +1,11 @@
+# Berksfile
+#
+# maintainer:: Exosphere Data, LLC
+# maintainer_email:: chef@exospheredata.com
+#
+# Copyright:: 2018, Exosphere Data, LLC, All Rights Reserved.
+#
+
+source 'https://supermarket.chef.io'
+
+cookbook 'veeam'

--- a/vmware/no_chef_server/veeam_proxy/files/solo.rb
+++ b/vmware/no_chef_server/veeam_proxy/files/solo.rb
@@ -1,0 +1,4 @@
+root = 'c:/chef/'
+file_cache_path root
+cookbook_path root + '/cookbooks'
+data_bag_path root + '/data_bags'

--- a/vmware/no_chef_server/veeam_proxy/main.tf
+++ b/vmware/no_chef_server/veeam_proxy/main.tf
@@ -1,0 +1,29 @@
+# Configure the VMware vSphere Provider
+provider "vsphere" {
+  user           = "${var.vsphere_user}"
+  password       = "${var.vsphere_password}"
+  vsphere_server = "${var.vsphere_server}"
+
+  # if you have a self-signed cert
+  allow_unverified_ssl = true
+}
+
+# Data resources will discover information about the vSphere environment to be used in other Resources.
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.vsphere_resource_pool}/Resources"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.vsphere_network_name}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_virtual_machine" "proxy_template" {
+  name          = "${var.proxy_template_path}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}

--- a/vmware/no_chef_server/veeam_proxy/output.tf
+++ b/vmware/no_chef_server/veeam_proxy/output.tf
@@ -1,0 +1,7 @@
+/*
+Output Variables
+*/
+
+output "proxy_host" {
+  value = "${vsphere_virtual_machine.proxy.*.default_ip_address}"
+}

--- a/vmware/no_chef_server/veeam_proxy/proxy.tf
+++ b/vmware/no_chef_server/veeam_proxy/proxy.tf
@@ -1,0 +1,237 @@
+# Terraform template for Veeam Proxy Servers
+#
+# Maintained by Exposphere Data, LLC
+# Version 1.0.0
+# Date 2018-08-14
+#
+# This template will deploy one or more Windows Templates to create Veeam Proxy Servers
+#
+
+resource "vsphere_virtual_machine" "proxy" {
+  count            = "${var.proxy_count}"
+  name             = "${format("${var.veeam_proxy_name}%02d", count.index+1)}"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  folder           = "${var.veeam_deployment_folder}"
+  guest_id         = "${data.vsphere_virtual_machine.proxy_template.guest_id}"
+
+  scsi_type        = "${data.vsphere_virtual_machine.proxy_template.scsi_type}"
+
+  num_cpus         = "${var.proxy_cpu_count}"
+  memory           = "${var.proxy_memory_size_mb}"
+
+  network_interface {
+    network_id     = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.proxy_template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.proxy_template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.proxy_template.disks.0.thin_provisioned}"
+  }
+
+  clone {
+    template_uuid = "${data.vsphere_virtual_machine.proxy_template.id}"
+
+    customize {
+      network_interface {}
+      windows_options {
+        computer_name  = "${format("${var.veeam_proxy_name}%02d", count.index+1)}"
+      }
+    }
+
+  }
+}
+resource "null_resource" "install_chef_proxy" {
+  count            = "${var.proxy_count}"
+  triggers {
+    instance_id = "${vsphere_virtual_machine.proxy.*.id[count.index]}"
+  }
+
+  depends_on = [
+    "vsphere_virtual_machine.proxy"
+  ]
+
+  connection {
+    host      = "${element(vsphere_virtual_machine.proxy.*.guest_ip_addresses.0, count.index)}"
+    type      = "winrm"
+    user      = "${var.proxy_admin_user}"
+    password  = "${var.proxy_admin_password}"
+    timeout   = "20m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install\""
+    ]
+  }
+
+  # =>
+  # => Execute the following upon destruction
+  # =>
+  provisioner "file" {
+    when        = "destroy"
+    source      = "${path.module}/scripts/prep_host.ps1"
+    destination = "C:\\tmp\\prep_host.ps1"
+  }
+
+  provisioner "remote-exec" {
+    when        = "destroy"
+    inline = [
+      "powershell.exe -File \"C:\\tmp\\prep_host.ps1\""
+    ]
+  }
+
+  provisioner "remote-exec" {
+    when        = "destroy"
+    inline = [
+      "powershell.exe -Command \"Remove-Item -Confirm:$False C:\\tmp\\prep_host.ps1\""
+    ]
+  }
+
+  provisioner "file" {
+    when        = "destroy"
+    source      = "${path.module}/files/Berksfile"
+    destination = "C:\\tmp\\chef_cookbooks\\Berksfile"
+  }
+  provisioner "file" {
+    when        = "destroy"
+    source      = "${path.module}/files/solo.rb"
+    destination = "C:\\tmp\\chef\\solo.rb"
+  }
+  provisioner "file" {
+    when        = "destroy"
+    content     = <<-EOF
+      {
+        "veeam": {
+          "installer": {
+            "package_url": "${var.veeam_installation_url}",
+            "package_checksum": "${var.veeam_installation_checksum}"
+          },
+          "version": "9.5",
+          "console": {
+            "accept_eula": true,
+            "keep_media": true
+          },
+          "proxy": {
+            "vbr_server": "${var.vbr_server_address}",
+            "vbr_username": "${var.vbr_admin_user}",
+            "vbr_password": "${var.vbr_admin_password}",
+            "proxy_username": "${var.proxy_admin_user}",
+            "proxy_password": "${var.proxy_admin_password}",
+            "use_ip_address": true,
+            "register": ${var.should_register_proxy == "true" ? true : false}
+          }
+        },
+        "run_list": [
+          "recipe[veeam::proxy_remove]"
+        ]
+      }
+    EOF
+    destination = "C:\\tmp\\chef\\dna.json"
+  }
+  provisioner "file" {
+    when        = "destroy"
+    source      = "${path.module}/scripts/bootstrap.ps1"
+    destination = "C:\\tmp\\chef-bootstrap.ps1"
+  }
+
+  # =>
+  # => Execute Bootstrap script to apply CHEF configuration and setup.
+  # =>
+  provisioner "remote-exec" {
+    when        = "destroy"
+    inline = [
+      "powershell.exe -Command \"C:\\tmp\\chef-bootstrap.ps1\""
+    ]
+  }
+}
+
+resource "null_resource" "bootstrap_proxy" {
+  count            = "${var.proxy_count}"
+  triggers {
+    instance_id = "${vsphere_virtual_machine.proxy.*.id[count.index]}",
+    should_register_proxy = "${var.should_register_proxy}"
+  }
+
+  depends_on = [
+    "null_resource.install_chef_proxy"
+  ]
+
+  connection {
+    host      = "${element(vsphere_virtual_machine.proxy.*.guest_ip_addresses.0, count.index)}"
+    type      = "winrm"
+    user      = "${var.proxy_admin_user}"
+    password  = "${var.proxy_admin_password}"
+    timeout   = "20m"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/scripts/prep_host.ps1"
+    destination = "C:\\tmp\\prep_host.ps1"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -File \"C:\\tmp\\prep_host.ps1\""
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -Command \"Remove-Item -Confirm:$False C:\\tmp\\prep_host.ps1\""
+    ]
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/files/Berksfile"
+    destination = "C:\\tmp\\chef_cookbooks\\Berksfile"
+  }
+  provisioner "file" {
+    source      = "${path.module}/files/solo.rb"
+    destination = "C:\\tmp\\chef\\solo.rb"
+  }
+  provisioner "file" {
+    content     = <<-EOF
+      {
+        "veeam": {
+          "installer": {
+            "package_url": "${var.veeam_installation_url}",
+            "package_checksum": "${var.veeam_installation_checksum}"
+          },
+          "version": "9.5",
+          "console": {
+            "accept_eula": true,
+            "keep_media": true
+          },
+          "proxy": {
+            "vbr_server": "${var.vbr_server_address}",
+            "vbr_username": "${var.vbr_admin_user}",
+            "vbr_password": "${var.vbr_admin_password}",
+            "proxy_username": "${var.proxy_admin_user}",
+            "proxy_password": "${var.proxy_admin_password}",
+            "use_ip_address": true,
+            "register": ${var.should_register_proxy == "true" ? true : false}
+          }
+        },
+        "run_list": [
+          "recipe[veeam::proxy_server]"
+        ]
+      }
+    EOF
+    destination = "C:\\tmp\\chef\\dna.json"
+  }
+  provisioner "file" {
+    source      = "${path.module}/scripts/bootstrap.ps1"
+    destination = "C:\\tmp\\chef-bootstrap.ps1"
+  }
+
+  # =>
+  # => Execute Bootstrap script to apply CHEF configuration and setup.
+  # =>
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -Command \"C:\\tmp\\chef-bootstrap.ps1\""
+    ]
+  }
+}

--- a/vmware/no_chef_server/veeam_proxy/scripts/bootstrap.ps1
+++ b/vmware/no_chef_server/veeam_proxy/scripts/bootstrap.ps1
@@ -1,0 +1,61 @@
+# Windows Bootstrap with Local Chef Client
+#
+# maintainer:: Exosphere Data, LLC
+# maintainer_email:: chef@exospheredata.com
+#
+# Copyright:: 2018, Exosphere Data, LLC, All Rights Reserved.
+#
+
+
+Write-Host "Package up Chef Cookbooks based on Berksfile"
+try {
+  Set-Location -Path C:\tmp\chef_cookbooks
+  if (Test-Path -Path C:\tmp\cookbooks.tar.gz) {
+    Write-Host "`tRemove Previous Cookbook Archive file"
+    Remove-Item -Confirm:$False C:\tmp\cookbooks.tar.gz
+  }
+
+  $berks_installed = [boolean](C:\opscode\chef\embedded\bin\gem.bat list berkshelf | Select-String berkshelf)
+  if (!$berks_installed) {
+    Write-Host "`tInstall Berkshelf Gem"
+    Invoke-Expression -Command "C:\opscode\chef\embedded\bin\gem.bat install berkshelf --no-ri --no-rdoc" | Out-Null
+    if($LASTEXITCODE -ne 0) { throw "Failed to install Berkshelf Gem"}
+  }
+
+  Write-Host "`tCreate Berks Package based on Berksfile"
+  $output = Invoke-Expression -Command "C:\opscode\chef\embedded\bin\berks.bat package --berksfile=Berksfile"
+  if($LASTEXITCODE -ne 0) { throw "Failed to package cookbook archive"}
+  $cookbook_archive = $output.split("/")[-1]
+
+  Write-Host "`tRename unique cookbook archive name to standard file name"
+  Move-Item -Path $cookbook_archive -Destination C:\tmp\cookbooks.tar.gz
+} catch {
+  throw $_.Exception.message
+  exit 1
+} finally {
+  Set-Location $PSScriptRoot
+}
+
+Write-Host "Configure files for bootstrapping"
+try {
+  if (Test-Path -Path C:\chef) {
+    Write-Host "`tRemove existing chef files and configurations"
+    Remove-Item -Recurse -Confirm:$False C:\chef\
+  }
+
+  Write-Host "`tSetup the repositories"
+  New-Item -Type Directory C:\chef\cookbooks | Out-Null
+
+  Move-Item -Path C:\tmp\chef\* -Destination C:\chef\
+} catch {
+  throw $_.Exception.message
+  exit 1
+}
+try {
+  Write-Host "Start the CHEF Client and configuration bootstrap"
+  Invoke-Expression -Command "C:\opscode\chef\embedded\bin\chef-solo.bat --recipe-url /tmp/cookbooks.tar.gz -c C:/chef/solo.rb -j C:/chef/dna.json -l info"
+  if($LASTEXITCODE -ne 0) { throw "Chef Boostrap Failed"}
+} catch {
+  throw $_.Exception.message
+  exit 1
+}

--- a/vmware/no_chef_server/veeam_proxy/scripts/prep_host.ps1
+++ b/vmware/no_chef_server/veeam_proxy/scripts/prep_host.ps1
@@ -1,0 +1,29 @@
+# Windows Host preparation for Bootstrapping
+#
+# maintainer:: Exosphere Data, LLC
+# maintainer_email:: chef@exospheredata.com
+#
+# Copyright:: 2018, Exosphere Data, LLC, All Rights Reserved.
+#
+
+
+Write-Host "Prepare the host for Chef Bootstrapping"
+try {
+  if (Test-Path -Path C:\tmp\chef) {
+    Write-Host "`tRemove Previous Temporary Chef upload location"
+    Remove-Item -Recurse -Confirm:$False C:\tmp\chef
+  }
+
+  if (Test-Path -Path C:\tmp\chef_cookbooks) {
+    Write-Host "`tRemove Previous Temporary Chef Cookbook location"
+    Remove-Item -Recurse -Confirm:$False C:\tmp\chef_cookbooks
+  }
+  Write-Host "`tSetup the repositories"
+  New-Item -Type Directory C:\tmp\chef\ | Out-Null
+  Write-Host "`tSetup the cookbook repositories"
+  New-Item -Type Directory C:\tmp\chef_cookbooks | Out-Null
+}
+catch {
+  throw $_.Exception.Message
+  exit 1
+}

--- a/vmware/no_chef_server/veeam_proxy/terraform.tfvars.example
+++ b/vmware/no_chef_server/veeam_proxy/terraform.tfvars.example
@@ -1,0 +1,73 @@
+
+# vCenter FQDN or IP to which the systems will be deployed.
+vsphere_server         = ""
+
+# vCenter Username with privileges to deploy machines
+vsphere_user           = ""
+
+# vCenter Password of User selected
+vsphere_password       = ""
+
+# vSphere Datacenter Name to which the systems will be deployed.
+datacenter             = ""
+
+# vSphere Cluster or Resource Pool to which the systems will be deployed.
+vsphere_resource_pool  = ""
+
+# vSphere Virtual Machine Network to which the systems will be attached.
+vsphere_network_name   = ""
+
+# vSphere Full Template Path from which the Proxy systems will be deployed.
+proxy_template_path    = ""
+
+# Total number of vCPUs to assign to Veeam Proxy Server
+proxy_cpu_count        = 2
+
+# Total amount of memory (MB) to assign to Veeam Proxy Server
+proxy_memory_size_mb   = 2048
+
+# Should the Veeam Proxy Server be registered to the Veeam VBR Server.
+# If false then the proxy server will not register.  This is handy for creating fast launch templates.
+should_register_proxy  = true
+
+# vSphere Folder to which the systems will be deployed.  Must exist prior to execution.
+veeam_deployment_folder= ""
+
+# Veeam VBR Server Address.  Must exist prior to execution.
+vbr_server_address     = ""
+
+# Username for Remote Windows Management Connections.  Must be in Domain\\username or username (for local accounts)  format.
+vbr_admin_user         = ""
+
+# Password for Remote Windows Management Connections
+vbr_admin_password     = ""
+
+# Username for Remote Windows Management Connections.  Must be in Domain\\username or username (for local accounts)  format.
+proxy_admin_user       = ""
+
+# Password for Remote Windows Management Connections
+proxy_admin_password   = ""
+
+# FQDN domain name
+domain_name            = ""
+
+# Enter the hostname prefix to give to the Veeam Proxy Server.  Must be less than 12 characters as proxies will receive a 3 digit identifier at the end of their name.
+veeam_proxy_name       = "proxy"
+
+# Number of Proxy Servers to create.  Zero will remove all proxies created by this Terraform State.
+proxy_count            = 0
+
+
+# Chef Configuration
+
+# Full URL from which the Veeam software will be downloaded.
+veeam_installation_url = "https://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.iso"
+
+# SHA256 Checksum for the ISO Url selected.
+veeam_installation_checksum = "9a6fa7d857396c058b2e65f20968de56f96bc293e0e8fd9f1a848c7d71534134"
+
+
+
+
+
+

--- a/vmware/no_chef_server/veeam_proxy/variables.tf
+++ b/vmware/no_chef_server/veeam_proxy/variables.tf
@@ -1,0 +1,123 @@
+
+variable "vsphere_server" {
+  type        = "string"
+  description = "vCenter FQDN or IP to which the systems will be deployed."
+}
+
+variable "vsphere_user" {
+  type        = "string"
+  description = "vCenter Username with privileges to deploy machines"
+}
+
+variable "vsphere_password" {
+  type        = "string"
+  description = "vCenter Password of User selected"
+}
+
+variable "datacenter" {
+  type        = "string"
+  description = "vSphere Datacenter Name to which the systems will be deployed."
+}
+
+variable "vsphere_resource_pool" {
+  type        = "string"
+  description = "vSphere Cluster or Resource Pool to which the systems will be deployed."
+}
+
+variable "vsphere_network_name" {
+  type        = "string"
+  description = "vSphere Virtual Machine Network to which the systems will be attached."
+}
+
+variable "proxy_template_path" {
+  type        = "string"
+  description = "[Optional] vSphere Full Template Path from which the Proxy systems will be deployed.  If empty or 'same' then the variable veeam_template_path will be used."
+  default     = "same"
+}
+
+variable "proxy_cpu_count" {
+  type        = "string"
+  description = "Total number of vCPUs to assign to Veeam Proxy Server"
+  default     = 2
+}
+
+variable "proxy_memory_size_mb" {
+  type        = "string"
+  description = "Total amount of memory (MB) to assign to Veeam Proxy Server."
+  default     = 2048
+}
+
+variable "should_register_proxy" {
+  type        = "string"
+  description = "Should the Veeam Proxy Server be registered to the Veeam VBR Server."
+  default     = "true"
+}
+
+variable "veeam_deployment_folder" {
+  type        = "string"
+  description = "vSphere Folder to which the systems will be deployed.  Must exist prior to execution."
+}
+
+variable "vbr_server_address" {
+  type        = "string"
+  description = "Veeam VBR Server Address.  Must exist prior to execution."
+}
+
+variable "vbr_admin_user" {
+  type        = "string"
+  description = "Username for Remote Windows Management Connections.  Must be in Domain\\username or username (for local accounts) format."
+}
+
+variable "vbr_admin_password" {
+  type        = "string"
+  description = "Password for Remote Windows Management Connections"
+}
+
+variable "proxy_admin_user" {
+  type        = "string"
+  description = "Username for Remote Windows Management Connections.  Must be in Domain\\username or username (for local accounts)  format."
+}
+
+variable "proxy_admin_password" {
+  type        = "string"
+  description = "Password for Remote Windows Management Connections"
+}
+
+variable "domain_name" {
+  type        = "string"
+  description = "FQDN domain name"
+}
+
+variable "veeam_proxy_name" {
+  type        = "string"
+  description = "Enter the hostname prefix to give to the Veeam Proxy Server.  Must be less than 12 characters as proxies will receive a 3 digit identifier at the end of their name."
+  default     = "proxy"
+}
+
+variable "proxy_count" {
+  type        = "string"
+  description = "Number of Proxy Servers to create.  Zero will remove all proxies created by this Terraform State"
+  default     = 0
+}
+
+
+# Chef Configuration
+
+variable "veeam_installation_url" {
+  type        = "string"
+  description = "Full URL from which the Veeam software will be downloaded."
+  default     = "https://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.iso"
+}
+
+variable "veeam_installation_checksum" {
+  type        = "string"
+  description = "SHA256 Checksum for the ISO Url selected."
+  default     = "9a6fa7d857396c058b2e65f20968de56f96bc293e0e8fd9f1a848c7d71534134"
+}
+
+
+
+
+
+
+

--- a/vmware/no_chef_server/veeam_standalone_full/README.md
+++ b/vmware/no_chef_server/veeam_standalone_full/README.md
@@ -1,5 +1,5 @@
-# Basic Deployment of Veeam Proxy Servers on VMware
-This set of templates will deploy one or more Veeam VMware Proxy Servers on VMware using Chef-Solo mode with the Chef Client.
+# Basic Deployment of Veeam on VMware
+This set of templates will deploy Veeam Backup and Replication server in a complete deployment along with an optional number of Veeam VMware Proxies on VMware using Chef-Solo mode with the Chef Client.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -49,22 +49,25 @@ The Terraform templates included in this repository requires Terraform to be ava
 | `datacenter` | String | vSphere Datacenter Name to which the systems will be deployed. | | X |
 | `vsphere_resource_pool` | String | vSphere Cluster or Resource Pool to which the systems will be deployed. | | X |
 | `vsphere_network_name` | String | vSphere Virtual Machine Network to which the systems will be attached. | | X |
+| `veeam_template_path` | String | vSphere Full Template Path from which the systems will be deployed.  Must include any vSphere folder names e.g Templates/windows_2016 | | X |
 
 ### Veeam Server Variables
 
 | Name | Type | Description | Default Value | Mandatory |
 | --- | --- | --- | --- | --- |
+| `vbr_cpu_count` | String | Total number of vCPUs to assign to Veeam VBR Server | 2 | X |
+| `vbr_memory_size_mb` | String | Total amount of memory (MB) to assign to Veeam VBR Server | 4096 | X |
 | `proxy_template_path` | String | Optional] vSphere Full Template Path from which the Proxy systems will be deployed.  If empty or 'same' then the variable veeam_template_path will be used. | "same" | X |
 | `proxy_cpu_count` | String | Total number of vCPUs to assign to Veeam Proxy Server | 2 | X |
 | `proxy_memory_size_mb` | String | Total amount of memory (MB) to assign to Veeam Proxy Server. | 2048 | X |
 | `should_register_proxy` | String | Should the Veeam Proxy Server be registered to the Veeam VBR Server. | "true" | X |
 | `veeam_deployment_folder` | String | vSphere Folder to which the systems will be deployed.  Must exist prior to execution. | | X |
-| `vbr_server_address` | String | Veeam VBR Server Address.  Must exist prior to execution. | | X |
 | `admin_user` | String | Username for Remote Windows Management Connections.  Must be in Domain\\username or .\\username format. | | X |
 | `admin_password` | String | Password for Remote Windows Management Connections | | X |
 | `proxy_admin_user` | String | Username for Remote Windows Management Connections.  Must be in Domain\\username or .\\username format. | | X |
 | `proxy_admin_password` | String | Password for Remote Windows Management Connections | | X |
 | `domain_name` | String | FQDN domain name | | X |
+| `veeam_server_name` | String | Enter the hostname to give to the Veeam Backup and Replication Server.  Should be less than 16 characters. | "veeam" | X |
 | `veeam_proxy_name` | String | Enter the hostname prefix to give to the Veeam Proxy Server.  Must be less than 12 characters as proxies will receive a 3 digit identifier at the end of their name. | "proxy" | X |
 | `proxy_count` | String | Number of Proxy Servers to create.  Zero will remove all proxies created by this Terraform State | 0 | X |
 
@@ -99,7 +102,6 @@ Below is a list of different command options when executing Terraform.
 | `terraform destroy` | Reverses the entire configuration and destroys the infrastructure. If the `-force` switch is added, then it will bypass the *Should proceed?* question. | **WARNING**: This will delete everything in your environment based on the templates.  If you only want to remove the proxies, then you can simply set the `proxy_count` variable as mentioned previously. |
 | `terraform apply -var proxy_count=1 -var should_register_proxy=false` | This command will build the Veeam VBR server and deploy one Proxy Server but not register the proxy to VBR. | This command is handy for staging a new Proxy Server template.  By deploying in this manner:<ol><li>you can prestage the installation of the Veeam components</li><li>shutdown the machine</li><li>clone to a new template</li><li>then power on the proxy server</li><li>finally, run the process again using `terraform apply -var proxy_count=0` to delete the proxy cleanly</li></ol>|
 
-
 ## License and Author
 
 _Note: This repository is not officially supported by or released by Veeam Software, Inc._
@@ -118,5 +120,6 @@ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
 either express or implied. See the License for the specific language governing permissions
 and limitations under the License.
 ```
+
 
 

--- a/vmware/no_chef_server/veeam_standalone_full/files/Berksfile
+++ b/vmware/no_chef_server/veeam_standalone_full/files/Berksfile
@@ -1,0 +1,11 @@
+# Berksfile
+#
+# maintainer:: Exosphere Data, LLC
+# maintainer_email:: chef@exospheredata.com
+#
+# Copyright:: 2018, Exosphere Data, LLC, All Rights Reserved.
+#
+
+source 'https://supermarket.chef.io'
+
+cookbook 'veeam'

--- a/vmware/no_chef_server/veeam_standalone_full/files/solo.rb
+++ b/vmware/no_chef_server/veeam_standalone_full/files/solo.rb
@@ -1,0 +1,4 @@
+root = 'c:/chef/'
+file_cache_path root
+cookbook_path root + '/cookbooks'
+data_bag_path root + '/data_bags'

--- a/vmware/no_chef_server/veeam_standalone_full/main.tf
+++ b/vmware/no_chef_server/veeam_standalone_full/main.tf
@@ -1,0 +1,45 @@
+# Configure the VMware vSphere Provider
+provider "vsphere" {
+  user           = "${var.vsphere_user}"
+  password       = "${var.vsphere_password}"
+  vsphere_server = "${var.vsphere_server}"
+
+  # if you have a self-signed cert
+  allow_unverified_ssl = true
+}
+
+# Data resources will discover information about the vSphere environment to be used in other Resources.
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.vsphere_resource_pool}/Resources"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.vsphere_network_name}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = "${var.veeam_template_path}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_virtual_machine" "proxy_template" {
+  name          = "${
+    var.proxy_template_path != ""
+    ?
+      var.proxy_template_path != "same"
+      ?
+        var.proxy_template_path
+      :
+        var.veeam_template_path
+    :
+      var.veeam_template_path
+    }"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+

--- a/vmware/no_chef_server/veeam_standalone_full/output.tf
+++ b/vmware/no_chef_server/veeam_standalone_full/output.tf
@@ -1,0 +1,10 @@
+/*
+Output Variables
+*/
+output "vbr_host" {
+  value = "${vsphere_virtual_machine.vbr_server.default_ip_address}"
+}
+
+output "proxy_host" {
+  value = "${vsphere_virtual_machine.proxy.*.default_ip_address}"
+}

--- a/vmware/no_chef_server/veeam_standalone_full/proxy.tf
+++ b/vmware/no_chef_server/veeam_standalone_full/proxy.tf
@@ -1,0 +1,238 @@
+# Terraform template for Veeam Proxy Servers
+#
+# Maintained by Exposphere Data, LLC
+# Version 1.0.0
+# Date 2018-08-14
+#
+# This template will deploy one or more Windows Templates to create Veeam Proxy Servers
+#
+
+resource "vsphere_virtual_machine" "proxy" {
+  count            = "${var.proxy_count}"
+  name             = "${format("${var.veeam_proxy_name}%02d", count.index+1)}"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  folder           = "${var.veeam_deployment_folder}"
+  guest_id         = "${data.vsphere_virtual_machine.proxy_template.guest_id}"
+
+  scsi_type        = "${data.vsphere_virtual_machine.proxy_template.scsi_type}"
+
+  num_cpus         = "${var.proxy_cpu_count}"
+  memory           = "${var.proxy_memory_size_mb}"
+
+  network_interface {
+    network_id     = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.proxy_template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.proxy_template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.proxy_template.disks.0.thin_provisioned}"
+  }
+
+  clone {
+    template_uuid = "${data.vsphere_virtual_machine.proxy_template.id}"
+
+    customize {
+      network_interface {}
+      windows_options {
+        computer_name  = "${format("${var.veeam_proxy_name}%02d", count.index+1)}"
+      }
+    }
+
+  }
+}
+resource "null_resource" "install_chef_proxy" {
+  count            = "${var.proxy_count}"
+  triggers {
+    instance_id = "${vsphere_virtual_machine.proxy.*.id[count.index]}"
+  }
+
+  depends_on = [
+    "vsphere_virtual_machine.proxy"
+  ]
+
+  connection {
+    host      = "${element(vsphere_virtual_machine.proxy.*.guest_ip_addresses.0, count.index)}"
+    type      = "winrm"
+    user      = "${var.proxy_admin_user}"
+    password  = "${var.proxy_admin_password}"
+    timeout   = "20m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install\""
+    ]
+  }
+
+  # =>
+  # => Execute the following upon destruction
+  # =>
+  provisioner "file" {
+    when        = "destroy"
+    source      = "${path.module}/scripts/prep_host.ps1"
+    destination = "C:\\tmp\\prep_host.ps1"
+  }
+
+  provisioner "remote-exec" {
+    when        = "destroy"
+    inline = [
+      "powershell.exe -File \"C:\\tmp\\prep_host.ps1\""
+    ]
+  }
+
+  provisioner "remote-exec" {
+    when        = "destroy"
+    inline = [
+      "powershell.exe -Command \"Remove-Item -Confirm:$False C:\\tmp\\prep_host.ps1\""
+    ]
+  }
+
+  provisioner "file" {
+    when        = "destroy"
+    source      = "${path.module}/files/Berksfile"
+    destination = "C:\\tmp\\chef_cookbooks\\Berksfile"
+  }
+  provisioner "file" {
+    when        = "destroy"
+    source      = "${path.module}/files/solo.rb"
+    destination = "C:\\tmp\\chef\\solo.rb"
+  }
+  provisioner "file" {
+    when        = "destroy"
+    content     = <<-EOF
+      {
+        "veeam": {
+          "installer": {
+            "package_url": "${var.veeam_installation_url}",
+            "package_checksum": "${var.veeam_installation_checksum}"
+          },
+          "version": "9.5",
+          "console": {
+            "accept_eula": true,
+            "keep_media": true
+          },
+          "proxy": {
+            "vbr_server": "${vsphere_virtual_machine.vbr_server.default_ip_address}",
+            "vbr_username": "${var.vbr_admin_user}",
+            "vbr_password": "${var.vbr_admin_password}",
+            "proxy_username": "${var.proxy_admin_user}",
+            "proxy_password": "${var.proxy_admin_password}",
+            "use_ip_address": true,
+            "register": ${var.should_register_proxy == "true" ? true : false}
+          }
+        },
+        "run_list": [
+          "recipe[veeam::proxy_remove]"
+        ]
+      }
+    EOF
+    destination = "C:\\tmp\\chef\\dna.json"
+  }
+  provisioner "file" {
+    when        = "destroy"
+    source      = "${path.module}/scripts/bootstrap.ps1"
+    destination = "C:\\tmp\\chef-bootstrap.ps1"
+  }
+
+  # =>
+  # => Execute Bootstrap script to apply CHEF configuration and setup.
+  # =>
+  provisioner "remote-exec" {
+    when        = "destroy"
+    inline = [
+      "powershell.exe -Command \"C:\\tmp\\chef-bootstrap.ps1\""
+    ]
+  }
+}
+
+resource "null_resource" "bootstrap_proxy" {
+  count            = "${var.proxy_count}"
+  triggers {
+    instance_id = "${vsphere_virtual_machine.proxy.*.id[count.index]}",
+    should_register_proxy = "${var.should_register_proxy}"
+  }
+
+  depends_on = [
+    "null_resource.install_chef_proxy",
+    "null_resource.bootstrap_vbr_server"
+  ]
+
+  connection {
+    host      = "${element(vsphere_virtual_machine.proxy.*.guest_ip_addresses.0, count.index)}"
+    type      = "winrm"
+    user      = "${var.proxy_admin_user}"
+    password  = "${var.proxy_admin_password}"
+    timeout   = "20m"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/scripts/prep_host.ps1"
+    destination = "C:\\tmp\\prep_host.ps1"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -File \"C:\\tmp\\prep_host.ps1\""
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -Command \"Remove-Item -Confirm:$False C:\\tmp\\prep_host.ps1\""
+    ]
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/files/Berksfile"
+    destination = "C:\\tmp\\chef_cookbooks\\Berksfile"
+  }
+  provisioner "file" {
+    source      = "${path.module}/files/solo.rb"
+    destination = "C:\\tmp\\chef\\solo.rb"
+  }
+  provisioner "file" {
+    content     = <<-EOF
+      {
+        "veeam": {
+          "installer": {
+            "package_url": "${var.veeam_installation_url}",
+            "package_checksum": "${var.veeam_installation_checksum}"
+          },
+          "version": "9.5",
+          "console": {
+            "accept_eula": true,
+            "keep_media": true
+          },
+          "proxy": {
+            "vbr_server": "${vsphere_virtual_machine.vbr_server.default_ip_address}",
+            "vbr_username": "${var.vbr_admin_user}",
+            "vbr_password": "${var.vbr_admin_password}",
+            "proxy_username": "${var.proxy_admin_user}",
+            "proxy_password": "${var.proxy_admin_password}",
+            "use_ip_address": true,
+            "register": ${var.should_register_proxy == "true" ? true : false}
+          }
+        },
+        "run_list": [
+          "recipe[veeam::proxy_server]"
+        ]
+      }
+    EOF
+    destination = "C:\\tmp\\chef\\dna.json"
+  }
+  provisioner "file" {
+    source      = "${path.module}/scripts/bootstrap.ps1"
+    destination = "C:\\tmp\\chef-bootstrap.ps1"
+  }
+
+  # =>
+  # => Execute Bootstrap script to apply CHEF configuration and setup.
+  # =>
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -Command \"C:\\tmp\\chef-bootstrap.ps1\""
+    ]
+  }
+}

--- a/vmware/no_chef_server/veeam_standalone_full/scripts/bootstrap.ps1
+++ b/vmware/no_chef_server/veeam_standalone_full/scripts/bootstrap.ps1
@@ -1,0 +1,61 @@
+# Windows Bootstrap with Local Chef Client
+#
+# maintainer:: Exosphere Data, LLC
+# maintainer_email:: chef@exospheredata.com
+#
+# Copyright:: 2018, Exosphere Data, LLC, All Rights Reserved.
+#
+
+
+Write-Host "Package up Chef Cookbooks based on Berksfile"
+try {
+  Set-Location -Path C:\tmp\chef_cookbooks
+  if (Test-Path -Path C:\tmp\cookbooks.tar.gz) {
+    Write-Host "`tRemove Previous Cookbook Archive file"
+    Remove-Item -Confirm:$False C:\tmp\cookbooks.tar.gz
+  }
+
+  $berks_installed = [boolean](C:\opscode\chef\embedded\bin\gem.bat list berkshelf | Select-String berkshelf)
+  if (!$berks_installed) {
+    Write-Host "`tInstall Berkshelf Gem"
+    Invoke-Expression -Command "C:\opscode\chef\embedded\bin\gem.bat install berkshelf --no-ri --no-rdoc" | Out-Null
+    if($LASTEXITCODE -ne 0) { throw "Failed to install Berkshelf Gem"}
+  }
+
+  Write-Host "`tCreate Berks Package based on Berksfile"
+  $output = Invoke-Expression -Command "C:\opscode\chef\embedded\bin\berks.bat package --berksfile=Berksfile"
+  if($LASTEXITCODE -ne 0) { throw "Failed to package cookbook archive"}
+  $cookbook_archive = $output.split("/")[-1]
+
+  Write-Host "`tRename unique cookbook archive name to standard file name"
+  Move-Item -Path $cookbook_archive -Destination C:\tmp\cookbooks.tar.gz
+} catch {
+  throw $_.Exception.message
+  exit 1
+} finally {
+  Set-Location $PSScriptRoot
+}
+
+Write-Host "Configure files for bootstrapping"
+try {
+  if (Test-Path -Path C:\chef) {
+    Write-Host "`tRemove existing chef files and configurations"
+    Remove-Item -Recurse -Confirm:$False C:\chef\
+  }
+
+  Write-Host "`tSetup the repositories"
+  New-Item -Type Directory C:\chef\cookbooks | Out-Null
+
+  Move-Item -Path C:\tmp\chef\* -Destination C:\chef\
+} catch {
+  throw $_.Exception.message
+  exit 1
+}
+try {
+  Write-Host "Start the CHEF Client and configuration bootstrap"
+  Invoke-Expression -Command "C:\opscode\chef\embedded\bin\chef-solo.bat --recipe-url /tmp/cookbooks.tar.gz -c C:/chef/solo.rb -j C:/chef/dna.json -l info"
+  if($LASTEXITCODE -ne 0) { throw "Chef Boostrap Failed"}
+} catch {
+  throw $_.Exception.message
+  exit 1
+}

--- a/vmware/no_chef_server/veeam_standalone_full/scripts/prep_host.ps1
+++ b/vmware/no_chef_server/veeam_standalone_full/scripts/prep_host.ps1
@@ -1,0 +1,29 @@
+# Windows Host preparation for Bootstrapping
+#
+# maintainer:: Exosphere Data, LLC
+# maintainer_email:: chef@exospheredata.com
+#
+# Copyright:: 2018, Exosphere Data, LLC, All Rights Reserved.
+#
+
+
+Write-Host "Prepare the host for Chef Bootstrapping"
+try {
+  if (Test-Path -Path C:\tmp\chef) {
+    Write-Host "`tRemove Previous Temporary Chef upload location"
+    Remove-Item -Recurse -Confirm:$False C:\tmp\chef
+  }
+
+  if (Test-Path -Path C:\tmp\chef_cookbooks) {
+    Write-Host "`tRemove Previous Temporary Chef Cookbook location"
+    Remove-Item -Recurse -Confirm:$False C:\tmp\chef_cookbooks
+  }
+  Write-Host "`tSetup the repositories"
+  New-Item -Type Directory C:\tmp\chef\ | Out-Null
+  Write-Host "`tSetup the cookbook repositories"
+  New-Item -Type Directory C:\tmp\chef_cookbooks | Out-Null
+}
+catch {
+  throw $_.Exception.Message
+  exit 1
+}

--- a/vmware/no_chef_server/veeam_standalone_full/terraform.tfvars.example
+++ b/vmware/no_chef_server/veeam_standalone_full/terraform.tfvars.example
@@ -1,0 +1,82 @@
+
+# vCenter FQDN or IP to which the systems will be deployed.
+vsphere_server         = ""
+
+# vCenter Username with privileges to deploy machines
+vsphere_user           = ""
+
+# vCenter Password of User selected
+vsphere_password       = ""
+
+# vSphere Datacenter Name to which the systems will be deployed.
+datacenter             = ""
+
+# vSphere Cluster or Resource Pool to which the systems will be deployed.
+vsphere_resource_pool  = ""
+
+# vSphere Virtual Machine Network to which the systems will be attached.
+vsphere_network_name   = ""
+
+# vSphere Full Template Path from which the systems will be deployed.  Must include any vSphere folder names e.g Templates/windows_2016
+veeam_template_path    = ""
+
+# Total number of vCPUs to assign to Veeam VBR Server
+vbr_cpu_count          =  2
+
+# Total amount of memory (MB) to assign to Veeam VBR Server
+vbr_memory_size_mb     = 4096
+
+# [Optional] vSphere Full Template Path from which the Proxy systems will be deployed.  If empty or 'same' then the variable veeam_template_path will be used.
+proxy_template_path    = "same"
+
+# Total number of vCPUs to assign to Veeam Proxy Server
+proxy_cpu_count        = 2
+
+# Total amount of memory (MB) to assign to Veeam Proxy Server
+proxy_memory_size_mb   = 2048
+
+# Should the Veeam Proxy Server be registered to the Veeam VBR Server.
+# If false then the proxy server will not register.  This is handy for creating fast launch templates.
+should_register_proxy  = true
+
+# vSphere Folder to which the systems will be deployed.  Must exist prior to execution.
+veeam_deployment_folder= ""
+
+# Username for Remote Windows Management Connections.  Must be in Domain\\username or username (for local accounts) format.
+vbr_admin_user             = ""
+
+# Password for Remote Windows Management Connections
+vbr_admin_password         = ""
+
+# Username for Remote Windows Management Connections.  Must be in Domain\\username or username (for local accounts) format.
+proxy_admin_user       = ""
+
+# Password for Remote Windows Management Connections
+proxy_admin_password   = ""
+
+# FQDN domain name
+domain_name            = ""
+
+# Enter the hostname to give to the Veeam Backup and Replication Server.  Should be less than 16 characters.
+veeam_server_name      = "veeam"
+
+# Enter the hostname prefix to give to the Veeam Proxy Server.  Must be less than 12 characters as proxies will receive a 3 digit identifier at the end of their name.
+veeam_proxy_name       = "proxy"
+
+# Number of Proxy Servers to create.  Zero will remove all proxies created by this Terraform State.
+proxy_count            = 0
+
+
+# Chef Configuration
+
+# Full URL from which the Veeam software will be downloaded.
+veeam_installation_url = "https://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.iso"
+
+# SHA256 Checksum for the ISO Url selected.
+veeam_installation_checksum = "9a6fa7d857396c058b2e65f20968de56f96bc293e0e8fd9f1a848c7d71534134"
+
+
+
+
+
+

--- a/vmware/no_chef_server/veeam_standalone_full/variables.tf
+++ b/vmware/no_chef_server/veeam_standalone_full/variables.tf
@@ -1,0 +1,141 @@
+
+variable "vsphere_server" {
+  type        = "string"
+  description = "vCenter FQDN or IP to which the systems will be deployed."
+}
+
+variable "vsphere_user" {
+  type        = "string"
+  description = "vCenter Username with privileges to deploy machines"
+}
+
+variable "vsphere_password" {
+  type        = "string"
+  description = "vCenter Password of User selected"
+}
+
+variable "datacenter" {
+  type        = "string"
+  description = "vSphere Datacenter Name to which the systems will be deployed."
+}
+
+variable "vsphere_resource_pool" {
+  type        = "string"
+  description = "vSphere Cluster or Resource Pool to which the systems will be deployed."
+}
+
+variable "vsphere_network_name" {
+  type        = "string"
+  description = "vSphere Virtual Machine Network to which the systems will be attached."
+}
+
+variable "veeam_template_path" {
+  type        = "string"
+  description = "vSphere Full Template Path from which the systems will be deployed.  Must include any vSphere folder names e.g Templates/windows_2016"
+}
+
+variable "vbr_cpu_count" {
+  type        = "string"
+  description = "Total number of vCPUs to assign to Veeam VBR Server"
+  default     = 2
+}
+
+variable "vbr_memory_size_mb" {
+  type        = "string"
+  description = "Total amount of memory (MB) to assign to Veeam VBR Server"
+  default     = 4096
+}
+
+variable "proxy_template_path" {
+  type        = "string"
+  description = "[Optional] vSphere Full Template Path from which the Proxy systems will be deployed.  If empty or 'same' then the variable veeam_template_path will be used."
+  default     = "same"
+}
+
+variable "proxy_cpu_count" {
+  type        = "string"
+  description = "Total number of vCPUs to assign to Veeam Proxy Server"
+  default     = 2
+}
+
+variable "proxy_memory_size_mb" {
+  type        = "string"
+  description = "Total amount of memory (MB) to assign to Veeam Proxy Server."
+  default     = 2048
+}
+
+variable "should_register_proxy" {
+  type        = "string"
+  description = "Should the Veeam Proxy Server be registered to the Veeam VBR Server. If false then the proxy server will not register.  This is handy for creating fast launch templates."
+  default     = "true"
+}
+
+variable "veeam_deployment_folder" {
+  type        = "string"
+  description = "vSphere Folder to which the systems will be deployed.  Must exist prior to execution."
+}
+
+variable "vbr_admin_user" {
+  type        = "string"
+  description = "Username for Remote Windows Management Connections.  Must be in Domain\\username or username (for local accounts) format."
+}
+
+variable "vbr_admin_password" {
+  type        = "string"
+  description = "Password for Remote Windows Management Connections"
+}
+
+variable "proxy_admin_user" {
+  type        = "string"
+  description = "Username for Remote Windows Management Connections.  Must be in Domain\\username or username (for local accounts) format."
+}
+
+variable "proxy_admin_password" {
+  type        = "string"
+  description = "Password for Remote Windows Management Connections"
+}
+
+variable "domain_name" {
+  type        = "string"
+  description = "FQDN domain name"
+}
+
+variable "veeam_server_name" {
+  type        = "string"
+  description = "Enter the hostname to give to the Veeam Backup and Replication Server.  Should be less than 16 characters."
+  default     = "veeam"
+}
+
+variable "veeam_proxy_name" {
+  type        = "string"
+  description = "Enter the hostname prefix to give to the Veeam Proxy Server.  Must be less than 12 characters as proxies will receive a 3 digit identifier at the end of their name."
+  default     = "proxy"
+}
+
+variable "proxy_count" {
+  type        = "string"
+  description = "Number of Proxy Servers to create.  Zero will remove all proxies created by this Terraform State"
+  default     = 0
+}
+
+
+# Chef Configuration
+
+variable "veeam_installation_url" {
+  type        = "string"
+  description = "Full URL from which the Veeam software will be downloaded."
+  default     = "https://download.veeam.com/VeeamBackup&Replication_9.5.0.1922.Update3a.iso"
+}
+
+variable "veeam_installation_checksum" {
+  type        = "string"
+  description = "SHA256 Checksum for the ISO Url selected."
+  default     = "9a6fa7d857396c058b2e65f20968de56f96bc293e0e8fd9f1a848c7d71534134"
+}
+
+
+
+
+
+
+

--- a/vmware/no_chef_server/veeam_standalone_full/vbr_server.tf
+++ b/vmware/no_chef_server/veeam_standalone_full/vbr_server.tf
@@ -1,0 +1,150 @@
+# Terraform template for Veeam VBR Server
+#
+# Maintained by Exposphere Data, LLC
+# Version 1.0.0
+# Date 2018-08-14
+#
+# This template will deploy a Windows Template to create Veeam VBR Server
+#
+
+resource "vsphere_virtual_machine" "vbr_server" {
+  name             = "${var.veeam_server_name}"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  folder           = "${var.veeam_deployment_folder}"
+  guest_id         = "${data.vsphere_virtual_machine.template.guest_id}"
+
+  scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
+
+  num_cpus = "${var.vbr_cpu_count}"
+  memory   = "${var.vbr_memory_size_mb}"
+
+  network_interface {
+    network_id = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+  }
+
+  clone {
+    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+
+    customize {
+      network_interface {}
+      windows_options {
+        computer_name  = "${var.veeam_server_name}"
+      }
+    }
+  }
+}
+
+# Install the Chef Client and configure the initial connection to the Chef Organization.
+# Note: On destroy, this client will
+resource "null_resource" "install_chef_vbr_server" {
+  triggers {
+    instance_id = "${vsphere_virtual_machine.vbr_server.id}"
+  }
+
+  depends_on = [
+    "vsphere_virtual_machine.vbr_server"
+  ]
+
+  connection {
+    host      = "${vsphere_virtual_machine.vbr_server.guest_ip_addresses.0}"
+    type      = "winrm"
+    user      = "${var.vbr_admin_user}"
+    password  = "${var.vbr_admin_password}"
+    timeout   = "20m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install\""
+    ]
+  }
+}
+
+resource "null_resource" "bootstrap_vbr_server" {
+  triggers {
+    instance_id = "${vsphere_virtual_machine.vbr_server.id}"
+  }
+
+  depends_on = [
+    "null_resource.install_chef_vbr_server"
+  ]
+
+  connection {
+    host      = "${vsphere_virtual_machine.vbr_server.guest_ip_addresses.0}"
+    type      = "winrm"
+    user      = "${var.vbr_admin_user}"
+    password  = "${var.vbr_admin_password}"
+    timeout   = "20m"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/scripts/prep_host.ps1"
+    destination = "C:\\tmp\\prep_host.ps1"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -File \"C:\\tmp\\prep_host.ps1\""
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -Command \"Remove-Item -Confirm:$False C:\\tmp\\prep_host.ps1\""
+    ]
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/files/Berksfile"
+    destination = "C:\\tmp\\chef_cookbooks\\Berksfile"
+  }
+  provisioner "file" {
+    source      = "${path.module}/files/solo.rb"
+    destination = "C:\\tmp\\chef\\solo.rb"
+  }
+  provisioner "file" {
+    content     = <<-EOF
+      {
+        "veeam": {
+          "installer": {
+            "package_url": "${var.veeam_installation_url}",
+            "package_checksum": "${var.veeam_installation_checksum}"
+          },
+          "version": "9.5",
+          "server": {
+            "accept_eula": true,
+            "keep_media": true,
+            "evaluation": false
+          },
+          "console": {
+            "accept_eula": true
+          }
+        },
+        "run_list": [
+          "recipe[veeam::standalone_complete]"
+        ]
+      }
+    EOF
+    destination = "C:\\tmp\\chef\\dna.json"
+  }
+  provisioner "file" {
+    source      = "${path.module}/scripts/bootstrap.ps1"
+    destination = "C:\\tmp\\chef-bootstrap.ps1"
+  }
+
+  # =>
+  # => Execute Bootstrap script to apply CHEF configuration and setup.
+  # =>
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe -Command \"C:\\tmp\\chef-bootstrap.ps1\""
+    ]
+  }
+}


### PR DESCRIPTION
Template Veeam VBR Server without Chef Server and Veeam Proxy without Chef Server
    ADD:  Terraform Template to build server, install chef-client, and execute bootstrap
    ADD:  Veeam VBR and Proxy Templates
    ADD:  Files/Berksfile and Files/solo.rb
    ADD:  Scripts/bootstrap.ps1 to configure the host using chef cookbooks in chf-solo mode.